### PR TITLE
Fix syntax errors in config plugins

### DIFF
--- a/plugins/with-admob-app-id.js
+++ b/plugins/with-admob-app-id.js
@@ -22,15 +22,10 @@ const withAdMobAndroid = (config) => {
       // Ensure the <application> tag exists
       const application = AndroidConfig.Manifest.getApplication(cfg.modResults);
       if (application) {
-        AndroidConfig.Manifest.add               
-          (application,             
-            'meta-data',
-          [  
-            {
-              'android:name': 'com.google.android.gms.ads.APPLICATION_ID',
-              'android:value': adMobAppId,
-            },
-          ]
+        AndroidConfig.Manifest.addMetaDataItem(
+          application,
+          'com.google.android.gms.ads.APPLICATION_ID',
+          adMobAppId
         );
       } else {
         console.warn("Android <application> tag not found in manifest.");

--- a/plugins/with-remove-admob-build-phase.js
+++ b/plugins/with-remove-admob-build-phase.js
@@ -5,7 +5,6 @@ function removeGoogleMobileAdsBuildPhase(config) {
   return withXcodeProject(config, async (config) => {
     const xcodeProject = config.modResults;
     const targetUuid = xcodeProject.getFirstTarget().uuid; // Get the main target UUID
-    const target = xcodeProject.getFirstTarget().target; // Get the target object
 
     let foundAndRemoved = false;
     
@@ -20,8 +19,8 @@ function removeGoogleMobileAdsBuildPhase(config) {
         console.log(`Removing problematic AdMob build phase: ${phase.shellScript}`);
         
         // Remove the phase from the target's buildPhases list
-        const buildPhasesArray = xcodeProject.get    
-        BuildPhase(targetUuid); // This should return the array of build phase UUIDs for the target
+        const buildPhasesArray =
+          xcodeProject.pbxNativeTargetSection()[targetUuid].buildPhases; // Array of build phase UUIDs for the target
         if (buildPhasesArray) {
           const phaseIndex = buildPhasesArray.indexOf(uuid);
           if (phaseIndex > -1) {


### PR DESCRIPTION
## Summary
- fix AdMob app id plugin: proper call to add meta data
- fix remove-AdMob build phase plugin: correct build phase retrieval

## Testing
- `npx jest --runTestsByPath __tests__/App.test.tsx --color` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6877c1b7b57883238ac8a293c957ff36