### PR TITLE
Use AdMob test IDs

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -33,8 +33,9 @@ export default {
       },
       // 👇 Your custom plugin reads the App IDs from here
       reactNativeGoogleMobileAds: {
-        ios_app_id: 'ca-app-pub-5506676208773786~5792481604',
-        android_app_id: 'ca-app-pub-5506676208773786~4366691423',
+        // Test App IDs from Google. Replace with your real IDs when publishing.
+        ios_app_id: 'ca-app-pub-3940256099942544~1458002511',
+        android_app_id: 'ca-app-pub-3940256099942544~3347511713',
       },
     },
     plugins: [

--- a/screens/MainScreen.js
+++ b/screens/MainScreen.js
@@ -18,9 +18,8 @@ import {
   TestIds,
 } from 'react-native-google-mobile-ads';
 
-const adUnitId = __DEV__
-  ? TestIds.REWARDED
-  : 'ca-app-pub-5506676208773786/4493407648';
+// Use Google's test AdMob unit ID until the app is ready for production.
+const adUnitId = TestIds.REWARDED;
 
 const rewarded = RewardedAd.createForAdRequest(adUnitId, {
   requestNonPersonalizedAdsOnly: true,


### PR DESCRIPTION
## Summary
- use Google test App IDs in the Expo config
- rely on `TestIds.REWARDED` for rewarded ads

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68792f380e608323b5a70ac173e1236e