### PR TITLE
Fix iOS build by updating safe-area-context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react": "18.2.0",
         "react-native": "0.79.5",
         "react-native-google-mobile-ads": "^9.1.2",
-        "react-native-safe-area-context": "4.8.2",
+        "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "~3.29.0"
       },
       "devDependencies": {
@@ -12950,9 +12950,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz",
-      "integrity": "sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.5.2.tgz",
+      "integrity": "sha512-t4YVbHa9uAGf+pHMabGrb0uHrD5ogAusSu842oikJ3YKXcYp6iB4PTGl0EZNkUIR3pCnw/CXKn42OCfhsS0JIw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react": "18.2.0",
     "react-native": "0.79.5",
     "react-native-google-mobile-ads": "^9.1.2",
-    "react-native-safe-area-context": "4.8.2",
+    "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "~3.29.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- bump `react-native-safe-area-context` to 5.5.2 to resolve iOS Yoga build errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798844b1e483239faaa75c76c6396a