### PR TITLE
Update Expo version and pin Metro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,12 @@
         "@react-native-async-storage/async-storage": "1.21.0",
         "@react-navigation/native": "^6.1.18",
         "@react-navigation/native-stack": "^6.11.0",
-        "expo": "^53.0.19",
+        "expo": "^53.0.20",
         "expo-build-properties": "~0.11.1",
         "expo-font": "^11.4.0",
         "expo-linear-gradient": "^12.7.0",
         "firebase": "^11.10.0",
+        "metro": "0.80.12",
         "react": "18.2.0",
         "react-native": "0.73.6",
         "react-native-google-mobile-ads": "^9.1.2",
@@ -8390,9 +8391,9 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "53.0.19",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.19.tgz",
-      "integrity": "sha512-hZWEKw6h5dlfKy6+c3f2exx5x3Loio8p0b2s/Pk1eQfTffqpkQRVVlOzcTWU1RSuMfc47ZMpr97pUJWQczOGsQ==",
+      "version": "53.0.20",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.20.tgz",
+      "integrity": "sha512-Nh+HIywVy9KxT/LtH08QcXqrxtUOA9BZhsXn3KCsAYA+kNb80M8VKN8/jfQF+I6CgeKyFKJoPNsWgI0y0VBGrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -8409,7 +8410,7 @@
         "expo-font": "~13.3.2",
         "expo-keep-awake": "~14.1.4",
         "expo-modules-autolinking": "2.1.14",
-        "expo-modules-core": "2.4.2",
+        "expo-modules-core": "2.5.0",
         "react-native-edge-to-edge": "1.6.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -8595,9 +8596,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.4.2.tgz",
-      "integrity": "sha512-RCb0wniYCJkxwpXrkiBA/WiNGxzYsEpL0sB50gTnS/zEfX3DImS2npc4lfZ3hPZo1UF9YC6OSI9Do+iacV0NUg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.5.0.tgz",
+      "integrity": "sha512-aIbQxZE2vdCKsolQUl6Q9Farlf8tjh/ROR4hfN1qT7QBGPl1XrJGnaOKkcgYaGrlzCPg/7IBe0Np67GzKMZKKQ==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.11.0",
-    "expo": "^53.0.19",
+    "expo": "^53.0.20",
     "expo-build-properties": "~0.11.1",
     "expo-font": "^11.4.0",
     "expo-linear-gradient": "^12.7.0",
@@ -24,7 +24,8 @@
     "react-native": "0.73.6",
     "react-native-google-mobile-ads": "^9.1.2",
     "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "~3.29.0"
+    "react-native-screens": "~3.29.0",
+    "metro": "0.80.12"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",


### PR DESCRIPTION
## Summary
- bump `expo` to 53.0.20
- pin Metro to 0.80.12 to match Expo's expected Metro version

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879957f68d483239deea304402cdd16