### PR TITLE
Fix AdMob plugin for new config API

### DIFF
--- a/__tests__/plugins.test.js
+++ b/__tests__/plugins.test.js
@@ -18,9 +18,9 @@ jest.mock('@expo/config-plugins', () => {
     },
     AndroidConfig: {
       Manifest: {
-        getApplication: () => android.manifest.application[0],
-        add: (app, _name, items) => {
-          app.meta = items;
+        getMainApplicationOrThrow: () => android.manifest.application[0],
+        addMetaDataItemToMainApplication: (app, _name, value) => {
+          app['meta-data'] = [{ $: { 'android:name': _name, 'android:value': value } }];
         },
       },
     },
@@ -64,7 +64,7 @@ describe('custom plugins', () => {
     const config = { extra: { reactNativeGoogleMobileAds: { ios_app_id: 'ios', android_app_id: 'android' } } };
     const result = withAdMobAppId(config);
     expect(result.ios.GADApplicationIdentifier).toBe('ios');
-    expect(result.android.manifest.application[0].meta[0]['android:value']).toBe('android');
+    expect(result.android.manifest.application[0]['meta-data'][0].$['android:value']).toBe('android');
   });
 
   it('patches Podfile contents', () => {

--- a/plugins/with-admob-app-id.js
+++ b/plugins/with-admob-app-id.js
@@ -19,24 +19,17 @@ const withAdMobAndroid = (config) => {
   return withAndroidManifest(config, (cfg) => {
     const adMobAppId = config.extra?.reactNativeGoogleMobileAds?.android_app_id;
     if (adMobAppId) {
-      // Ensure the <application> tag exists
-      const application = AndroidConfig.Manifest.getApplication(cfg.modResults);
-      if (application) {
-        AndroidConfig.Manifest.add               
-          (application,             
-            'meta-data',
-          [  
-            {
-              'android:name': 'com.google.android.gms.ads.APPLICATION_ID',
-              'android:value': adMobAppId,
-            },
-          ]
+      try {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(cfg.modResults);
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication,
+          'com.google.android.gms.ads.APPLICATION_ID',
+          adMobAppId,
         );
-      } else {
-        console.warn("Android <application> tag not found in manifest.");
+      } catch (error) {
+        console.warn('Failed to add AdMob App ID to AndroidManifest:', error.message);
       }
     } else {
-      console.warn("AdMob Android App ID not found in config.extra.reactNativeGoogleMobileAds.android_app_id");
+      console.warn('AdMob Android App ID not found in config.extra.reactNativeGoogleMobileAds.android_app_id');
     }
     return cfg;
   });


### PR DESCRIPTION
## Summary
- update the custom AdMob plugin to use AndroidConfig helpers
- adjust plugin tests for updated metadata handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879a51be9d883238e5787242da69f3b