### PR TITLE
Fix Metro usage for Expo 53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@react-native/babel-preset": "0.73.21",
         "@testing-library/react-native": "^13.2.0",
         "jest": "^30.0.4",
-        "metro": "0.79.0",
         "react-test-renderer": "18.2.0"
       }
     },
@@ -7831,6 +7830,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10668,9 +10673,9 @@
       "license": "MIT"
     },
     "node_modules/metro": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.79.0.tgz",
-      "integrity": "sha512-TmQjGRZViwK2tGPJqOBabIxqtPKjQwn7NRtWwYgplB7B+u0/PbrIxJ7AJAGgb0aAqLtAuwYbVejg3Fyy4UKtow==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.12.tgz",
+      "integrity": "sha512-1UsH5FzJd9quUsD1qY+zUG4JY3jo3YEMxbMYH9jT6NK3j4iORhlwTK8fYTfAUBhDKjgLfKjAh7aoazNE23oIRA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -10687,35 +10692,33 @@
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.15.0",
+        "hermes-parser": "0.23.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
-        "jest-worker": "^27.2.0",
+        "jest-worker": "^29.6.3",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.79.0",
-        "metro-cache": "0.79.0",
-        "metro-cache-key": "0.79.0",
-        "metro-config": "0.79.0",
-        "metro-core": "0.79.0",
-        "metro-file-map": "0.79.0",
-        "metro-minify-terser": "0.79.0",
-        "metro-resolver": "0.79.0",
-        "metro-runtime": "0.79.0",
-        "metro-source-map": "0.79.0",
-        "metro-symbolicate": "0.79.0",
-        "metro-transform-plugins": "0.79.0",
-        "metro-transform-worker": "0.79.0",
+        "metro-babel-transformer": "0.80.12",
+        "metro-cache": "0.80.12",
+        "metro-cache-key": "0.80.12",
+        "metro-config": "0.80.12",
+        "metro-core": "0.80.12",
+        "metro-file-map": "0.80.12",
+        "metro-resolver": "0.80.12",
+        "metro-runtime": "0.80.12",
+        "metro-source-map": "0.80.12",
+        "metro-symbolicate": "0.80.12",
+        "metro-transform-plugins": "0.80.12",
+        "metro-transform-worker": "0.80.12",
         "mime-types": "^2.1.27",
-        "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^3.0.2",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
         "strip-ansi": "^6.0.0",
         "throat": "^5.0.0",
-        "ws": "^7.5.1",
+        "ws": "^7.5.10",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -10726,13 +10729,14 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.79.0.tgz",
-      "integrity": "sha512-RtDWsdlmP8K04zfIMpD3vosfAROdzL0Z28yDeC5OvqD7bUn0ZQUxlFbG/HdrdXDkCe8+55F2ZxLGMG95Mlvf9A==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.12.tgz",
+      "integrity": "sha512-YZziRs0MgA3pzCkkvOoQRXjIoVjvrpi/yRlJnObyIvMP6lFdtyG4nUGIwGY9VXnBvxmXD6mPY2e+NSw6JAyiRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "hermes-parser": "0.15.0",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.23.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10740,55 +10744,60 @@
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.15.0.tgz",
-      "integrity": "sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
+      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
       "license": "MIT"
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.15.0.tgz",
-      "integrity": "sha512-Q1uks5rjZlE9RjMMjSUCkGrEIPI5pKJILeCtK1VmTj7U4pf3wVPoo+cxfu+s4cBAPy2JzikIIdCZgBoR6x7U1Q==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
+      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.15.0"
+        "hermes-estree": "0.23.1"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.79.0.tgz",
-      "integrity": "sha512-6suCHTcDTCvbi7rDftvj+0+6GkGPSqqAmVUgasz9JZy1zyUM5ezdHrfN5E06B7LgGzXEsb4xF/zHJ0foq98SOA==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.12.tgz",
+      "integrity": "sha512-p5kNHh2KJ0pbQI/H7ZBPCEwkyNcSz7OUkslzsiIWBMPQGFJ/xArMwkV7I+GJcWh+b4m6zbLxE5fk6fqbVK1xGA==",
       "license": "MIT",
       "dependencies": {
-        "metro-core": "0.79.0",
-        "rimraf": "^3.0.2"
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "metro-core": "0.80.12"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.79.0.tgz",
-      "integrity": "sha512-D+pHt35guISi02ToNWaj1YGOiHfkeR63LZJUraUalVsLX8QHXuYkOYbyhhnO8Y5933Ro6DpSad61drvqxRhzfQ==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.12.tgz",
+      "integrity": "sha512-o4BspKnugg/pE45ei0LGHVuBJXwRgruW7oSFAeSZvBKA/sGr0UhOGY3uycOgWInnS3v5yTTfiBA9lHlNRhsvGA==",
       "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.79.0.tgz",
-      "integrity": "sha512-X0DD0Y5+sp9A54Xj9n+haUaGIfGIHzoRw1ZdR1MPS3IKNP1pK+iU7tkFLp/w5yT2NzcGDttNim5LLOykZD41jA==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.12.tgz",
+      "integrity": "sha512-4rwOWwrhm62LjB12ytiuR5NgK1ZBNr24/He8mqCsC+HXZ+ATbrewLNztzbAZHtFsrxP4D4GLTGgh96pCpYLSAQ==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
+        "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.6.3",
-        "metro": "0.79.0",
-        "metro-cache": "0.79.0",
-        "metro-core": "0.79.0",
-        "metro-runtime": "0.79.0"
+        "metro": "0.80.12",
+        "metro-cache": "0.80.12",
+        "metro-core": "0.80.12",
+        "metro-runtime": "0.80.12"
       },
       "engines": {
         "node": ">=18"
@@ -10859,31 +10868,32 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.79.0.tgz",
-      "integrity": "sha512-VWTSfcjadvtP6wECU+EN2iBx0d1M1CFnl+icCzV8D9F2XaB4Fj/xQHwZCSbLYvEAkCYsr8/XkDw7pFd4kd8VLg==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.12.tgz",
+      "integrity": "sha512-QqdJ/yAK+IpPs2HU/h5v2pKEdANBagSsc6DRSjnwSyJsCoHlmyJKCaCJ7KhWGx+N4OHxh37hoA8fc2CuZbx0Fw==",
       "license": "MIT",
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.79.0"
+        "metro-resolver": "0.80.12"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.79.0.tgz",
-      "integrity": "sha512-g2TKD352ei+CahyowDPibH4SZ73kX/x9SWAicv9cQ0Hy2UtCDWP6jaeT4mDUISFZOoK1vGojr9JJRyyR+nWD1A==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.12.tgz",
+      "integrity": "sha512-sYdemWSlk66bWzW2wp79kcPMzwuG32x1ZF3otI0QZTmrnTaaTiGyhE66P1z6KR4n2Eu5QXiABa6EWbAQv0r8bw==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.0.3",
         "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
-        "jest-util": "^27.2.0",
-        "jest-worker": "^27.2.0",
+        "jest-worker": "^29.6.3",
         "micromatch": "^4.0.4",
         "node-abort-controller": "^3.1.1",
         "nullthrows": "^1.1.1",
@@ -10896,30 +10906,40 @@
         "fsevents": "^2.3.2"
       }
     },
-    "node_modules/metro-file-map/node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+    "node_modules/metro-file-map/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "license": "MIT",
       "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/metro-file-map/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/metro-file-map/node_modules/@types/yargs": {
-      "version": "16.0.9",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.9.tgz",
-      "integrity": "sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
+    "node_modules/metro-file-map/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "license": "MIT"
     },
     "node_modules/metro-file-map/node_modules/debug": {
       "version": "2.6.9",
@@ -10931,12 +10951,12 @@
       }
     },
     "node_modules/metro-file-map/node_modules/jest-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
-      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -10944,21 +10964,22 @@
         "picomatch": "^2.2.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/metro-file-map/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/metro-file-map/node_modules/ms": {
@@ -10995,11 +11016,12 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.79.0.tgz",
-      "integrity": "sha512-7VYxy/wAHtuVz3RXAiyMvP6Qp6BGR+Ibl0FI4Ky/s4aMFUB0nW/uQuH1rH0fJMR5WxCmt4qAA4+uW2rZguIvVw==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.12.tgz",
+      "integrity": "sha512-muWzUw3y5k+9083ZoX9VaJLWEV2Jcgi+Oan0Mmb/fBNMPqP9xVDuy4pOMn/HOiGndgfh/MK7s4bsjkyLJKMnXQ==",
       "license": "MIT",
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
@@ -11007,48 +11029,43 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.79.0.tgz",
-      "integrity": "sha512-ABPYo9EHXTjE3lhDo9SXw/EH1OPltYTv8a7MC+b4ei9xLd7DuiHNvlT4YpZjWADSKrtM5xqbZHFboTgzyBSjWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/metro-runtime": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.79.0.tgz",
-      "integrity": "sha512-C9OMx/7qVb39ToIGxvHlltfNqE1xWw0DfJISLIc74CZGthTCPa1nlxvog2t8Pc7FlLJPmjDeDkJVEPKQM8jKfg==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.12.tgz",
+      "integrity": "sha512-PR24gYRZnYHM3xT9pg6BdbrGbM/Cu1TcyIFBVlAk7qDAuHkUNQ1nMzWumWs+kwSvtd9eZGzHoucGJpTUEeLZAw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
+        "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/metro-runtime/node_modules/react-refresh": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
-      "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
+    "node_modules/metro-runtime": {
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.12.tgz",
+      "integrity": "sha512-LIx7+92p5rpI0i6iB4S4GBvvLxStNt6fF0oPMaUd1Weku7jZdfkCZzmrtDD9CSQ6EPb0T9NUZoyXIxlBa3wOCw==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.79.0.tgz",
-      "integrity": "sha512-vLVoeWCLq5kGJfwZt54wYAI6GpfZKDb+P9OTv9CcTnPD8EjF7EgZpSO+NNZDKwGqtmwy/JItzzEQDIx6HXs7dw==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.12.tgz",
+      "integrity": "sha512-o+AXmE7hpvM8r8MKsx7TI21/eerYYy2DCDkWfoBkv+jNkl61khvDHlQn0cXZa6lrcNZiZkl9oHSMcwLLIrFmpw==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.20.0",
         "@babel/types": "^7.20.0",
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.79.0",
+        "metro-symbolicate": "0.80.12",
         "nullthrows": "^1.1.1",
-        "ob1": "0.79.0",
+        "ob1": "0.80.12",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -11057,13 +11074,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.79.0.tgz",
-      "integrity": "sha512-8o6D1YmoL7Jl45/HekmKem9wtVL7E/W94wW23ajmTx7gnFrpquxNf4plWYtQ0P/Y0K/r1ACRXxnndLjNhGFw5A==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.12.tgz",
+      "integrity": "sha512-/dIpNdHksXkGHZXARZpL7doUzHqSNxgQ8+kQGxwpJuHnDhGkENxB5PS2QBaTDdEcmyTMjS53CN1rl9n1gR6fmw==",
       "license": "MIT",
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.79.0",
+        "metro-source-map": "0.80.12",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -11077,15 +11095,16 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.79.0.tgz",
-      "integrity": "sha512-3cItCo50SwjaQuqBwHpyzobEL2E6NAeuttebhaipuD+xc96lUXL1LvmXXic2zUNkOZj02zlEZvgG2CqmlXQaYQ==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.12.tgz",
+      "integrity": "sha512-WQWp00AcZvXuQdbjQbx1LzFR31IInlkCDYJNRs6gtEtAyhwpMMlL2KcHmdY+wjDO9RPcliZ+Xl1riOuBecVlPA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/template": "^7.0.0",
         "@babel/traverse": "^7.20.0",
+        "flow-enums-runtime": "^0.0.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -11093,26 +11112,63 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.79.0.tgz",
-      "integrity": "sha512-eHyzqSKUVKH4amKB1MA0Yp4fH7wvYvvyWX1JTqb32f/eGWiBdVcjIpQLI46CECzDqNY5pJcolBEB4ARs4ZhskA==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.12.tgz",
+      "integrity": "sha512-KAPFN1y3eVqEbKLx1I8WOarHPqDMUa8WelWxaJCNKO/yHCP26zELeqTJvhsQup+8uwB6EYi/sp0b6TGoh6lOEA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "metro": "0.79.0",
-        "metro-babel-transformer": "0.79.0",
-        "metro-cache": "0.79.0",
-        "metro-cache-key": "0.79.0",
-        "metro-source-map": "0.79.0",
-        "metro-transform-plugins": "0.79.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.80.12",
+        "metro-babel-transformer": "0.80.12",
+        "metro-cache": "0.80.12",
+        "metro-cache-key": "0.80.12",
+        "metro-minify-terser": "0.80.12",
+        "metro-source-map": "0.80.12",
+        "metro-transform-plugins": "0.80.12",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/metro/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "license": "MIT"
     },
     "node_modules/metro/node_modules/ci-info": {
       "version": "2.0.0",
@@ -11130,32 +11186,65 @@
       }
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.15.0.tgz",
-      "integrity": "sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
+      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.15.0.tgz",
-      "integrity": "sha512-Q1uks5rjZlE9RjMMjSUCkGrEIPI5pKJILeCtK1VmTj7U4pf3wVPoo+cxfu+s4cBAPy2JzikIIdCZgBoR6x7U1Q==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
+      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.15.0"
+        "hermes-estree": "0.23.1"
+      }
+    },
+    "node_modules/metro/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/jest-util/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/metro/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/metro/node_modules/ms": {
@@ -11163,6 +11252,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/metro/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/metro/node_modules/supports-color": {
       "version": "8.1.1",
@@ -11555,10 +11656,13 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.79.0.tgz",
-      "integrity": "sha512-9jFD2M7GcotKTNkS8N5EjyGh+g838p2WCTC6k1LQnx6+MUycoI24stT3Qxuk6DJBEWVTEb2l2GZ6GzUjqpBqOA==",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.12.tgz",
+      "integrity": "sha512-VMArClVT6LkhUGpnuEoBuyjG9rzUyEzg4PDkav6wK1cLhOK02gPCYFxoiB4mqVnrMhDpIzJcrGNAMVi9P+hXrw==",
       "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@react-native/babel-preset": "0.73.21",
     "@testing-library/react-native": "^13.2.0",
     "jest": "^30.0.4",
-    "metro": "0.80.0",
     "react-test-renderer": "18.2.0"
   },
   "expo": {


### PR DESCRIPTION
## Summary
- remove custom metro version from `package.json`
- update lockfile via `npm install`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879d2c46e688323a53d9ff5ac657093