### PR TITLE
Fix Metro config for Expo SDK 53

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,10 +1,6 @@
-const { getDefaultConfig } = require('expo/metro-config');
+const { getDefaultConfig } = require('@expo/metro-config');
 
-// Get the default configuration
+// Use the default Metro configuration for Expo SDK 53
 const config = getDefaultConfig(__dirname);
 
-// Add 'cjs' to the source extensions
-config.resolver.sourceExts.push('cjs');
-
-// Export the modified configuration
 module.exports = config;


### PR DESCRIPTION
## Summary
- use `@expo/metro-config` defaults
- remove unsupported Metro plugin references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879d6abc9b08323a56bb906f8dd1bae