### PR TITLE
Use default Expo Metro config

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,4 @@
 const { getDefaultConfig } = require('@expo/metro-config');
 
-// Use the default Metro configuration for Expo SDK 53
-const config = getDefaultConfig(__dirname);
-
-module.exports = config;
+// Use the default Expo Metro configuration
+module.exports = getDefaultConfig(__dirname);


### PR DESCRIPTION
## Summary
- simplify `metro.config.js` to use `@expo/metro-config`

## Testing
- `npm test`
- `eas build -p ios` *(fails: requires Expo login)*

------
https://chatgpt.com/codex/tasks/task_e_6879d7dfeb5c8323af1533dcce402eff