### PR TITLE
Improve EAS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,5 @@ To build this project with [EAS Build](https://docs.expo.dev/build/introduction/
 
 Ensure the `EAS_ACCESS_TOKEN` secret (and optional keystore secrets) are configured in your repository settings before triggering the workflow.
 
+If building locally, run `eas login` or set `EXPO_TOKEN` to authenticate before running `eas build`.
+


### PR DESCRIPTION
## Summary
- clarify that a local EAS build requires authentication

## Testing
- `npx eas-cli build --platform android --profile development --local --non-interactive --output build-output.apk` *(fails: An Expo user account is required)*

------
https://chatgpt.com/codex/tasks/task_e_687a6cee02188323bb43505848662903