### PR TITLE
Improve local EAS build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,5 @@ To build this project with [EAS Build](https://docs.expo.dev/build/introduction/
 
 Ensure the `EAS_ACCESS_TOKEN` secret (and optional keystore secrets) are configured in your repository settings before triggering the workflow.
 
+For local builds run `./scripts/eas-build-local.sh`. This script checks that you are logged in (or have `EXPO_TOKEN` set) before invoking `eas build`.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
         "@types/react-test-renderer": "^19.1.0",
         "jest": "^30.0.4",
         "react-test-renderer": "18.2.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest",
-    "generate-keystore": "./scripts/generate-android-keystore.sh"
+    "generate-keystore": "./scripts/generate-android-keystore.sh",
+    "build-local": "./scripts/eas-build-local.sh"
   },
   "dependencies": {
     "@expo/config-plugins": "^7.8.0",

--- a/scripts/eas-build-local.sh
+++ b/scripts/eas-build-local.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! npx -y eas-cli whoami >/dev/null 2>&1 && [ -z "${EXPO_TOKEN:-}" ]; then
+  echo "Expo authentication required. Run 'eas login' or set EXPO_TOKEN." >&2
+  exit 1
+fi
+
+./scripts/generate-android-keystore.sh
+
+npx -y eas-cli build --platform android --profile development --local --non-interactive --output build-output.apk "$@"


### PR DESCRIPTION
## Summary
- add `eas-build-local.sh` to wrap the local EAS build
- mention the helper script in the README
- expose a `build-local` npm script

## Testing
- `npm test`
- `npx -y eas-cli build --platform android --profile development --local --non-interactive --output build-output.apk` *(fails: Expo authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_687a6cee02188323bb43505848662903