### PR TITLE
Fix build by patching Metro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ yarn-error.log
 
 # Expo development directory
 .expo/
+android/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "GenesisApp",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo/config-plugins": "^7.8.0",
         "@react-native-async-storage/async-storage": "1.21.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest",
-    "generate-keystore": "./scripts/generate-android-keystore.sh"
+    "generate-keystore": "./scripts/generate-android-keystore.sh",
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
     "@expo/config-plugins": "^7.8.0",

--- a/patches/importLocationsPlugin.js
+++ b/patches/importLocationsPlugin.js
@@ -1,0 +1,46 @@
+"use strict";
+
+function importLocationsPlugin({ types: t }) {
+  return {
+    visitor: {
+      ImportDeclaration(path, { importDeclarationLocs }) {
+        if (path.node.importKind !== "type" && path.node.loc != null) {
+          importDeclarationLocs.add(locToKey(path.node.loc));
+        }
+      },
+      ExportDeclaration(path, { importDeclarationLocs }) {
+        if (
+          path.node.source != null &&
+          path.node.exportKind !== "type" &&
+          path.node.loc != null
+        ) {
+          importDeclarationLocs.add(locToKey(path.node.loc));
+        }
+      },
+      Program(path, state) {
+        state.importDeclarationLocs = new Set();
+        const metroMetadata = state.file.metadata;
+        if (!metroMetadata.metro) {
+          metroMetadata.metro = {
+            unstable_importDeclarationLocs: state.importDeclarationLocs,
+          };
+        } else {
+          metroMetadata.metro.unstable_importDeclarationLocs =
+            state.importDeclarationLocs;
+        }
+      },
+    },
+  };
+}
+const MISSING_LOC = {
+  line: -1,
+  column: -1,
+};
+function locToKey(loc) {
+  const { start = MISSING_LOC, end = MISSING_LOC } = loc;
+  return `${start.line},${start.column}:${end.line},${end.column}`;
+}
+module.exports = {
+  importLocationsPlugin,
+  locToKey,
+};

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+// Destination within metro package
+const destPath = path.join(__dirname, '..', 'node_modules', 'metro', 'src', 'ModuleGraph', 'worker', 'importLocationsPlugin.js');
+const srcPath = path.join(__dirname, '..', 'patches', 'importLocationsPlugin.js');
+
+if (!fs.existsSync(destPath)) {
+  try {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(srcPath, destPath);
+    console.log('Patched importLocationsPlugin into metro.');
+  } catch (err) {
+    console.warn('Failed to patch importLocationsPlugin:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add Android directory to `.gitignore`
- add `postinstall` script to patch missing Metro plugin
- include the missing `importLocationsPlugin` implementation

## Testing
- `npm install`
- `npm test`
- `npm start` *(fails: fetch failed due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687bbcf92ea48323b8e52dfdaadc830a