### PR TITLE
Disable workflow push trigger

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -2,8 +2,7 @@ name: EAS Build
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
+  # The push trigger was removed to prevent builds from running on every commit.
 
 jobs:
   build-ios:


### PR DESCRIPTION
## Summary
- stop building on every push to `main`

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888a712624c8323853944a23f81aa5a