### PR TITLE
Fix Expo pods install error

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -14,3 +14,34 @@ if (!fs.existsSync(destPath)) {
     console.warn('Failed to patch importLocationsPlugin:', err);
   }
 }
+
+function patchPodspec(podspecPath, searchValue, replacement) {
+  try {
+    if (!fs.existsSync(podspecPath)) {
+      return;
+    }
+    const contents = fs.readFileSync(podspecPath, 'utf8');
+    if (contents.includes(replacement)) {
+      return;
+    }
+    const updated = contents.replace(searchValue, replacement);
+    fs.writeFileSync(podspecPath, updated);
+    console.log(`Patched ${path.basename(podspecPath)}`);
+  } catch (err) {
+    console.warn(`Failed to patch ${podspecPath}:`, err);
+  }
+}
+
+const expoPodspec = path.join(__dirname, '..', 'node_modules', 'expo', 'Expo.podspec');
+patchPodspec(
+  expoPodspec,
+  'compiler_flags = get_folly_config()[:compiler_flags]',
+  "compiler_flags = (defined?(get_folly_config) ? get_folly_config()[:compiler_flags] : folly_flags())"
+);
+
+const corePodspec = path.join(__dirname, '..', 'node_modules', 'expo-modules-core', 'ExpoModulesCore.podspec');
+patchPodspec(
+  corePodspec,
+  "compiler_flags = get_folly_config()[:compiler_flags] + ' ",
+  "compiler_flags = (defined?(get_folly_config) ? get_folly_config()[:compiler_flags] : folly_flags()) + ' "
+);


### PR DESCRIPTION
## Summary
- patch `Expo.podspec` and `ExpoModulesCore.podspec` during postinstall

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c80cbb7f88323b0bcf985772f3cfd