### PR TITLE
Fix Podfile for Firebase and AdMob

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -52,6 +52,7 @@ export default {
         {
           ios: {
             useFrameworks: 'static',
+            useModularHeaders: true,
           },
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@react-navigation/native": "^6.1.18",
         "@react-navigation/native-stack": "^6.11.0",
         "expo": "^53.0.20",
-        "expo-build-properties": "~0.11.1",
+        "expo-build-properties": "~0.14.8",
         "expo-font": "^11.4.0",
         "expo-linear-gradient": "^12.7.0",
         "react": "18.2.0",
@@ -6933,13 +6933,13 @@
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.11.1.tgz",
-      "integrity": "sha512-m4j4aEjFaDuBE6KWYMxDhWgLzzSmpE7uHKAwtvXyNmRK+6JKF0gjiXi0sXgI5ngNppDQpsyPFMvqG7uQpRuCuw==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.14.8.tgz",
+      "integrity": "sha512-GTFNZc5HaCS9RmCi6HspCe2+isleuOWt2jh7UEKHTDQ9tdvzkIoWc7U6bQO9lH3Mefk4/BcCUZD/utl7b1wdqw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
-        "semver": "^7.5.3"
+        "semver": "^7.6.0"
       },
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.11.0",
     "expo": "^53.0.20",
-    "expo-build-properties": "~0.11.1",
+    "expo-build-properties": "~0.14.8",
     "expo-font": "^11.4.0",
     "expo-linear-gradient": "^12.7.0",
     "@react-native-firebase/app": "^19.1.1",

--- a/plugins/with-custom-podfile.js
+++ b/plugins/with-custom-podfile.js
@@ -9,10 +9,17 @@ const withCustomPodfile = (config) => {
       const podfilePath = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
       let contents = fs.readFileSync(podfilePath, 'utf8');
 
-      if (!contents.includes('use_frameworks!')) {
+      if (!/use_frameworks!/.test(contents)) {
         contents = contents.replace(
           /use_expo_modules!\(\)/,
           `use_expo_modules!()\n  use_frameworks! :linkage => :static`
+        );
+      }
+
+      if (!contents.includes('use_modular_headers!')) {
+        contents = contents.replace(
+          /use_frameworks!.*\n/,
+          (match) => `${match}  use_modular_headers!\n`
         );
       }
 


### PR DESCRIPTION
## Summary
- enable ios.useModularHeaders in build-properties config
- update custom Podfile plugin to insert `use_modular_headers!`
- bump expo-build-properties to v0.14.8

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cad2e38948323b631d22edd9ff6d0