### PR TITLE
Configure iOS frameworks via expo-build-properties

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -56,7 +56,6 @@ export default {
           },
         },
       ],
-      './plugins/with-custom-podfile.js',
     ],
   },
 };


### PR DESCRIPTION
## Summary
- keep iOS framework configuration in `expo-build-properties`
- remove custom Podfile plugin usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d29114c3c8323931cece24a6f8d94