### PR TITLE
Align metro packages with Expo SDK 53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
         "@types/react": "^19.1.9",
         "@types/react-test-renderer": "^19.1.0",
         "jest": "^30.0.4",
-        "metro": "^0.82.5",
-        "metro-config": "^0.82.5",
-        "metro-resolver": "^0.82.5",
+        "metro": "^0.82.0",
+        "metro-config": "^0.82.0",
+        "metro-resolver": "^0.82.0",
         "react-test-renderer": "18.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "@types/react": "^19.1.9",
     "@types/react-test-renderer": "^19.1.0",
     "jest": "^30.0.4",
-    "metro": "^0.82.5",
-    "metro-config": "^0.82.5",
-    "metro-resolver": "^0.82.5",
+    "metro": "^0.82.0",
+    "metro-config": "^0.82.0",
+    "metro-resolver": "^0.82.0",
     "react-test-renderer": "18.2.0"
   },
   "expo": {


### PR DESCRIPTION
## Summary
- align metro packages to version `^0.82.0` to match Expo SDK 53
- run unit tests
- execute expo doctor (fails due to network restrictions)

## Testing
- `npm test`
- `npx expo-doctor` *(fails: connect ENETUNREACH api.expo.dev)*

------
https://chatgpt.com/codex/tasks/task_e_688d2afc4da48323b5a51a959ed4890c