### PR TITLE
fix: patch Podfile after Expo prebuild via EAS hook

### DIFF
--- a/.eas.json
+++ b/.eas.json
@@ -9,12 +9,18 @@
       "distribution": "internal",
       "ios": {
         "simulator": true
+      },
+      "hooks": {
+        "pre-build": "node ./scripts/patchPodfile.js"
       }
     },
     "preview": {
       "distribution": "internal",
       "ios": {
         "simulator": false
+      },
+      "hooks": {
+        "pre-build": "node ./scripts/patchPodfile.js"
       }
     },
     "production": {
@@ -31,6 +37,9 @@
       "node": "18.18.2",
       "android": {
         "credentialsSource": "local"
+      },
+      "hooks": {
+        "pre-build": "node ./scripts/patchPodfile.js"
       }
     }
   },

--- a/eas.json
+++ b/eas.json
@@ -9,12 +9,18 @@
       "distribution": "internal",
       "ios": {
         "simulator": true
+      },
+      "hooks": {
+        "pre-build": "node ./scripts/patchPodfile.js"
       }
     },
     "preview": {
       "distribution": "internal",
       "ios": {
         "simulator": false
+      },
+      "hooks": {
+        "pre-build": "node ./scripts/patchPodfile.js"
       }
     },
     "production": {
@@ -31,6 +37,9 @@
       "node": "18.18.2",
       "android": {
         "credentialsSource": "local"
+      },
+      "hooks": {
+        "pre-build": "node ./scripts/patchPodfile.js"
       }
     }
   },


### PR DESCRIPTION
## Summary
- ensure expo prebuild Podfile patch runs during EAS builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689636172ea88323bed0c665832aafd3