### PR TITLE
chore: simplify tsconfig to resolve missing type declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": "./",
-    "types": ["react", "react-test-renderer", "jest"],
-    "moduleResolution": "bundler",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
+    "types": ["react", "react-test-renderer", "jest"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]


### PR DESCRIPTION
## Summary
- remove custom path and baseUrl entries from tsconfig to allow default type resolution

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f15f91248323bfa84369a5f2c67f