### PR TITLE
fix: strip invalid iOS -G compiler flag after prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "jest",
     "generate-keystore": "./scripts/generate-android-keystore.sh",
-    "postinstall": "node ./scripts/postinstall.js && node ./scripts/patchPodfile.js"
+    "postinstall": "node ./scripts/postinstall.js && node ./scripts/patchPodfile.js && node ./scripts/patchFlags.js"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.1.2",

--- a/scripts/patchFlags.js
+++ b/scripts/patchFlags.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const roots = ['ios', 'ios/Pods'];
+const targets = [];
+function collect(p) {
+  if (!fs.existsSync(p)) return;
+  const st = fs.lstatSync(p);
+  if (st.isFile()) {
+    if (/\.(xcconfig|pbxproj)$/.test(p)) targets.push(p);
+  } else if (st.isDirectory()) {
+    for (const f of fs.readdirSync(p)) collect(path.join(p, f));
+  }
+}
+roots.forEach(collect);
+
+let patched = 0;
+for (const f of targets) {
+  let s = fs.readFileSync(f, 'utf8');
+  const before = s;
+  // Remove standalone "-G" in flags (keep lowercase "-g")
+  s = s.replace(/(^|[\s,])\-G(?=($|[\s,]))/g, '$1');
+  // Tidy spaces/commas
+  s = s.replace(/,\s*,/g, ',').replace(/\s{2,}/g, ' ');
+  if (s !== before) { fs.writeFileSync(f, s); patched++; console.log('Patched:', f); }
+}
+console.log(patched ? `✅ Removed '-G' from ${patched} file(s).` : 'ℹ️ No -G flags found.');


### PR DESCRIPTION
## Summary
- remove standalone `-G` tokens from iOS build configs
- run flag cleanup script during postinstall

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e692b60d08323ba2c394cb2d9e78e