### PR TITLE
chore: add asc app id for ios auto submit

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,5 +20,9 @@
       "android": { "credentialsSource": "local" }
     }
   },
-  "submit": { "production": {} }
+  "submit": {
+    "production": {
+      "ios": { "ascAppId": "6745538429" }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add ascAppId to production submit profile for auto-submitting iOS builds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e708dde188323ba17657a14a1a144