### PR TITLE
Fix iOS build by stripping unsupported '-G' flags

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -13,5 +13,7 @@ target 'GenesisApp' do
 
   post_install do |installer|
     react_native_post_install(installer)
+    # Strip unsupported '-G' flags from generated pod configs
+    system('node', File.join(__dir__, '..', 'scripts', 'patchFlags.js'))
   end
 end

--- a/scripts/patchFlags.js
+++ b/scripts/patchFlags.js
@@ -1,7 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 
-const roots = ['ios', 'ios/Pods'];
+// Work from the repository root regardless of the current working directory
+const rootDir = path.join(__dirname, '..');
+const roots = [
+  path.join(rootDir, 'ios'),
+  path.join(rootDir, 'ios', 'Pods'),
+];
 const targets = [];
 function collect(p) {
   if (!fs.existsSync(p)) return;


### PR DESCRIPTION
## Summary
- run patchFlags.js after `pod install` so generated Pods configs no longer include `-G`
- make patchFlags.js work from any working directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e7312642c832388f0d3aab593e104