### PR TITLE
fix: remove unsupported -G flag from iOS build

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -13,7 +13,22 @@ target 'GenesisApp' do
 
   post_install do |installer|
     react_native_post_install(installer)
-    # Strip unsupported '-G' flags from generated pod configs
-    system('node', File.join(__dir__, '..', 'scripts', 'patchFlags.js'))
+
+    targets = installer.pods_project.targets + installer.aggregate_targets.flat_map { |t| t.user_project.native_targets }
+
+    targets.each do |target|
+      target.build_configurations.each do |config|
+        %w[OTHER_CFLAGS OTHER_CPLUSPLUSFLAGS OTHER_LDFLAGS].each do |flag|
+          value = config.build_settings[flag]
+          next if value.nil?
+
+          if value.is_a?(Array)
+            config.build_settings[flag] = value.reject { |f| f == '-G' }
+          elsif value.is_a?(String)
+            config.build_settings[flag] = value.gsub(/\b-G\b/, '').squeeze(' ').strip
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- strip unsupported `-G` flags from Pods and project build settings during `post_install`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e98a931a08323bb349d9a42cde2cb