### PR TITLE
Strip unsupported -G flag from iOS builds

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -22,13 +22,22 @@ target 'GenesisApp' do
           value = config.build_settings[flag]
           next if value.nil?
 
+          cleaned = false
           if value.is_a?(Array)
-            config.build_settings[flag] = value.reject { |f| f == '-G' }
+            new_val = value.reject { |f| f == '-G' }
+            cleaned = new_val.length != value.length
+            config.build_settings[flag] = new_val
           elsif value.is_a?(String)
-            config.build_settings[flag] = value.gsub(/\b-G\b/, '').squeeze(' ').strip
+            new_val = value.gsub(/(\s)-G(\s|$)/, '\1\2').squeeze(' ').strip
+            cleaned = new_val != value
+            config.build_settings[flag] = new_val
           end
+
+          puts "Removed -G from #{target.name} #{config.name} #{flag}" if cleaned
         end
       end
     end
+
+    system('node', File.join(__dir__, '..', 'scripts', 'stripDashG.js'))
   end
 end

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "jest",
     "generate-keystore": "./scripts/generate-android-keystore.sh",
-    "postinstall": "node ./scripts/postinstall.js && node ./scripts/patchPodfile.js && node ./scripts/patchFlags.js"
+    "postinstall": "node ./scripts/postinstall.js && node ./scripts/patchPodfile.js && node ./scripts/patchFlags.js && node ./scripts/stripDashG.js"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.1.2",

--- a/scripts/stripDashG.js
+++ b/scripts/stripDashG.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const rootDir = path.join(__dirname, '..');
+const iosDir = path.join(rootDir, 'ios');
+const supportDir = path.join(iosDir, 'Pods', 'Target Support Files');
+const pbxproj = path.join(iosDir, 'Pods', 'Pods.xcodeproj', 'project.pbxproj');
+
+const files = [];
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      walk(full);
+    } else if (stat.isFile() && full.endsWith('.xcconfig')) {
+      files.push(full);
+    }
+  }
+}
+
+walk(supportDir);
+if (fs.existsSync(pbxproj)) {
+  files.push(pbxproj);
+}
+
+let edited = 0;
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  const updated = content.replace(/\s-G(\s|$)/g, ' $1');
+  if (updated !== content) {
+    fs.writeFileSync(file, updated);
+    console.log('Patched', file);
+    edited++;
+  }
+}
+
+const result = spawnSync('grep', ['-R', '--line-number', '-E', '\\b-G\\b', iosDir], { stdio: 'inherit' });
+if (result.status === 0) {
+  process.exit(1);
+}
+process.exit(0);
+


### PR DESCRIPTION
## Summary
- remove standalone `-G` from iOS build flags and log cleans
- add script to recursively strip `-G` from Pod support files
- invoke script during npm and CocoaPods post-install

## Testing
- `npm test`
- `node scripts/stripDashG.js`
- `grep -R --line-number -E "\b-G\b" ios || echo OK`


------
https://chatgpt.com/codex/tasks/task_e_689e9ceb939083239064bd020193787d