### PR TITLE
Ensure -G flags are stripped after pod install

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,5 +39,7 @@ target 'GenesisApp' do
     end
 
     system('node', File.join(__dir__, '..', 'scripts', 'stripDashG.js'))
+    # Also run the more exhaustive flag patcher to catch any new entries.
+    system('node', File.join(__dir__, '..', 'scripts', 'patchFlags.js'))
   end
 end

--- a/scripts/stripDashG.js
+++ b/scripts/stripDashG.js
@@ -30,7 +30,9 @@ if (fs.existsSync(pbxproj)) {
 let edited = 0;
 for (const file of files) {
   const content = fs.readFileSync(file, 'utf8');
-  const updated = content.replace(/\s-G(\s|$)/g, ' $1');
+  let updated = content.replace(/(^|[\s,])-G(?=($|[\s,]))/gm, '$1$2');
+  // Tidy up any leftover spacing or commas
+  updated = updated.replace(/,\s*,/g, ',').replace(/\s{2,}/g, ' ');
   if (updated !== content) {
     fs.writeFileSync(file, updated);
     console.log('Patched', file);


### PR DESCRIPTION
## Summary
- run `patchFlags.js` during CocoaPods post_install to catch any new `-G` flags
- refine `stripDashG.js` to remove `-G` cleanly and tidy whitespace

## Testing
- `npm test`
- `grep -R --line-number '\b-G\b' Pods` (no matches)
- `pod install --allow-root` *(fails: Could not automatically select an Xcode project)*

------
https://chatgpt.com/codex/tasks/task_e_689eacbbb41083238bb83122e0fde597