### PR TITLE
Configure iOS Firebase and AdMob support

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -16,8 +16,11 @@ export default {
       bundleIdentifier: 'com.adrianpavlick8.genesisapp',
       buildNumber: '1',
       supportsTablet: true,
+      googleServicesFile: './GoogleService-Info.plist',
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
+        // Test AdMob app ID for development; replace with production ID when ready.
+        GADApplicationIdentifier: 'ca-app-pub-3940256099942544~1458002511',
       },
     },
     android: {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -2,6 +2,8 @@ require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 platform :ios, '13.4'
+use_frameworks! :linkage => :static
+use_modular_headers!
 
 target 'GenesisApp' do
   config = use_native_modules!


### PR DESCRIPTION
## Summary
- ensure iOS pods use static frameworks and modular headers
- register Firebase plist and AdMob app ID for iOS builds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36e1426908323b8a4141403a494f7