### PR TITLE
refactor: migrate database calls to RNFirebase API

### DIFF
--- a/__tests__/MainScreen.test.js
+++ b/__tests__/MainScreen.test.js
@@ -20,10 +20,18 @@ jest.mock('react-native-google-mobile-ads', () => {
   };
 });
 
-jest.mock('../firebaseConfig', () => ({ auth: { onAuthStateChanged: jest.fn(() => jest.fn()) }, rtdb: {} }));
+jest.mock('../firebaseConfig', () => ({ auth: { onAuthStateChanged: jest.fn(() => jest.fn()) } }));
 
 jest.mock('@react-native-firebase/auth', () => () => ({ onAuthStateChanged: jest.fn(() => jest.fn()) }));
-jest.mock('@react-native-firebase/database', () => ({ ref: jest.fn(), get: jest.fn(), set: jest.fn(), onValue: jest.fn() }));
+jest.mock('@react-native-firebase/database', () => () => ({
+  ref: jest.fn(() => ({
+    once: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn(),
+    set: jest.fn(),
+    update: jest.fn(),
+  })),
+}));
 
 describe('MainScreen', () => {
   let rewardMock;


### PR DESCRIPTION
## Summary
- replace Web SDK style Realtime Database helpers with React Native Firebase instance methods
- adjust mining service and main screen to use rtdb.ref().once(), .set(), .update(), .on()
- clean up MainScreen database listener with rtdb.off()

## Testing
- `npm test __tests__/MainScreen.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3ebbfe2d8832382d33b4919b1cfec