### PR TITLE
Initialize AdMob and configure iOS settings

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { View, ActivityIndicator } from 'react-native';
 import { useFonts } from 'expo-font';
+import mobileAds from 'react-native-google-mobile-ads';
 
 import AuthScreen from './screens/AuthScreen';
 import MainScreen from './screens/MainScreen';
@@ -18,6 +19,10 @@ export default function App() {
     'FiraCode-Regular': require('./assets/fonts/FiraCode-Regular.ttf'),
     'FiraCode-Bold': require('./assets/fonts/FiraCode-Bold.ttf'),
   });
+
+  useEffect(() => {
+    mobileAds().initialize();
+  }, []);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user) => {

--- a/app.config.js
+++ b/app.config.js
@@ -18,6 +18,11 @@ export default {
       supportsTablet: true,
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
+        GADApplicationIdentifier:
+          process.env.EXPO_PUBLIC_IOS_ADMOB_APP_ID ||
+          'ca-app-pub-3940256099942544~1458002511',
+        NSUserTrackingUsageDescription:
+          'This identifier will be used to deliver personalized ads to you.',
       },
     },
     android: {
@@ -43,6 +48,17 @@ export default {
             useFrameworks: 'static',
             useModularHeaders: true,
           },
+        },
+      ],
+      [
+        'react-native-google-mobile-ads',
+        {
+          iosAppId:
+            process.env.EXPO_PUBLIC_IOS_ADMOB_APP_ID ||
+            'ca-app-pub-3940256099942544~1458002511',
+          androidAppId:
+            process.env.EXPO_PUBLIC_ANDROID_ADMOB_APP_ID ||
+            'ca-app-pub-3940256099942544~3347511713',
         },
       ],
     ],


### PR DESCRIPTION
## Summary
- initialize Google Mobile Ads SDK on app startup
- configure iOS Info.plist with AdMob identifiers and tracking description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a409ffb4688323b18b5e437d0fbb69