### PR TITLE
Handle errors in native module and JS wrapper

### DIFF
--- a/ios/MyModule.m
+++ b/ios/MyModule.m
@@ -1,0 +1,56 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
+
+@interface MyModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation MyModule {
+  dispatch_queue_t _serialQueue;
+}
+
+RCT_EXPORT_MODULE();
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    // Create a serial queue to ensure thread safety instead of using a global concurrent queue
+    _serialQueue = dispatch_queue_create("com.genesisapp.MyModule", DISPATCH_QUEUE_SERIAL);
+  }
+  return self;
+}
+
+// Example method exposed to JavaScript that processes a string input
+RCT_EXPORT_METHOD(doSomething:(NSString *)input callback:(RCTResponseSenderBlock)callback)
+{
+  // Validate input from JavaScript
+  if (input == nil || [input length] == 0) {
+    RCTLogError(@"doSomething called with invalid input");
+    if (callback) {
+      callback(@[@"Input cannot be empty", [NSNull null]]);
+    }
+    return;
+  }
+
+  RCTLogInfo(@"doSomething called with input: %@", input);
+
+  // Run work asynchronously on the module's serial queue for thread safety
+  dispatch_async(_serialQueue, ^{
+    @try {
+      // Simulate some native work with the input
+      NSString *result = [NSString stringWithFormat:@"Processed %@", input];
+      RCTLogInfo(@"doSomething processed: %@", result);
+      if (callback) {
+        callback(@[[NSNull null], result]);
+      }
+    }
+    @catch (NSException *exception) {
+      // Catch any Objective-C exceptions and send them back to JavaScript
+      RCTLogError(@"Exception in doSomething: %@", exception);
+      if (callback) {
+        callback(@[exception.reason ?: @"Unknown error", [NSNull null]]);
+      }
+    }
+  });
+}
+
+@end

--- a/services/myModule.js
+++ b/services/myModule.js
@@ -1,0 +1,34 @@
+import { NativeModules } from 'react-native';
+
+const { MyModule } = NativeModules;
+
+/**
+ * Wrapper around the native MyModule.doSomething method.
+ * Validates input and handles errors gracefully.
+ * @param {string} input
+ * @returns {Promise<string>} result from native code
+ */
+export const doSomething = async (input) => {
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    console.log('doSomething called with invalid input');
+    throw new Error('Input must be a non-empty string');
+  }
+
+  try {
+    console.log('Calling MyModule.doSomething with input:', input);
+    return await new Promise((resolve, reject) => {
+      MyModule.doSomething(input, (error, result) => {
+        if (error) {
+          console.log('MyModule.doSomething returned error:', error);
+          reject(new Error(error));
+        } else {
+          console.log('MyModule.doSomething returned result:', result);
+          resolve(result);
+        }
+      });
+    });
+  } catch (err) {
+    console.log('Error invoking MyModule.doSomething:', err);
+    throw err;
+  }
+};


### PR DESCRIPTION
## Summary
- add serial-queue native module with input validation and exception handling
- add JavaScript wrapper that validates inputs and logs errors when calling native code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7ee2133c48323baf98fee83dde1bf