### PR TITLE
chore: ignore ios directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ yarn-error.log
 # Expo development directory
 .expo/
 android/
+/ios


### PR DESCRIPTION
## Summary
- ignore ios directory in gitignore for CNG/Prebuild

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf6fb9a6c83239464e39806334a0e